### PR TITLE
Fix description

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
         <title>eXistdb - The Open Source Native XML Database</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
         <meta name="description" content="High-performance native XML database engine and all-in-one solution for application building."/>
-        <meta name="description" content="eXist Solutions Long Term Support (LTS) and Service Level Agreement (SLA) order form"/>
         <meta name="keywords" lang="en" content="eXistdb, nosql, database, xml, xquery, xforms, xsl, forms, web, development"/>
         <meta name="keywords" lang="en" content="eXistdb, nosql, database, xml, xquery, xforms, xsl, forms, web, entwicklung"/>
         <meta name="author" content="eXist Solutions GmbH"/>


### PR DESCRIPTION
When pasting a link to http://exist-db.org into Social media, the second description meta tag often causes the wrong summary to be displayed.