### PR TITLE
Ensure dates of blog posts are rendered in English

### DIFF
--- a/news.xql
+++ b/news.xql
@@ -37,7 +37,7 @@ return
                     else if ($age < xdt:dayTimeDuration("P14D")) then
                         days-from-duration($age) || " days ago"
                     else
-                        format-dateTime($date, "[MNn] [D00] [Y0000]")
+                        format-dateTime($date, "[MNn] [D00], [Y0000]", "en", (), ())
                 }
                 </div>
                 <a href="{$path}/{$entry/wiki:id/string()}">{ $entry/atom:title/string() }</a>


### PR DESCRIPTION
Currently the dates on exist-db.org are "augusti 01 2018, juli 25 2018, juli 24 2018"